### PR TITLE
Fix crash due to uppercase container image

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -39,7 +39,7 @@ sable_hostname: ""
 # technical limitations.
 sable_path_prefix: /
 
-sable_container_image: "{{ sable_container_image_registry_prefix }}SableClient/Sable:{{ sable_container_image_tag }}"
+sable_container_image: "{{ sable_container_image_registry_prefix }}sableclient/sable:{{ sable_container_image_tag }}"
 sable_container_image_tag: "{{ sable_version }}"
 sable_container_image_registry_prefix: "{{ sable_container_image_registry_prefix_upstream }}"
 sable_container_image_registry_prefix_upstream: "{{ sable_container_image_registry_prefix_upstream_default }}"


### PR DESCRIPTION
'Ensure Sable container image is pulled via community.docker.docker_image' in the ansible playbook failed with  'Bad Request ("invalid reference format: repository name (SableClient/Sable) must be lowercase").'.